### PR TITLE
Send `NetworkError` if upload encoding fails

### DIFF
--- a/ProjectTemplate/Services/Network/Network.swift
+++ b/ProjectTemplate/Services/Network/Network.swift
@@ -53,10 +53,9 @@ final class Network: Networking {
                         uploadRequest
                             .validate()
                             .handleResponse(observer: observer)
-
                     case .failure(let error):
                         let networkError = NetworkError(error: error, request: nil, response: nil, data: nil)
-                        observer.send(error: .upload(networkError))
+                        observer.send(error: .network(networkError))
                     }
             }
         }

--- a/ProjectTemplate/Services/Network/Network.swift
+++ b/ProjectTemplate/Services/Network/Network.swift
@@ -55,7 +55,8 @@ final class Network: Networking {
                             .handleResponse(observer: observer)
 
                     case .failure(let error):
-                        observer.send(error: .upload(error))
+                        let networkError = NetworkError(error: error, request: nil, response: nil, data: nil)
+                        observer.send(error: .upload(networkError))
                     }
             }
         }

--- a/ProjectTemplate/Services/Network/NetworkStructs.swift
+++ b/ProjectTemplate/Services/Network/NetworkStructs.swift
@@ -26,7 +26,7 @@ struct RequestResponse<Value> {
 
 enum RequestError: Error {
     case network(NetworkError)
-    case upload(Error)
+    case upload(NetworkError)
     case missingRefreshToken
 }
 

--- a/ProjectTemplate/Services/Network/NetworkStructs.swift
+++ b/ProjectTemplate/Services/Network/NetworkStructs.swift
@@ -26,20 +26,19 @@ struct RequestResponse<Value> {
 
 enum RequestError: Error {
     case network(NetworkError)
-    case upload(NetworkError)
     case missingRefreshToken
 }
 
 extension RequestError: ErrorPresentable {
     var title: String? {
         switch self {
-        case .missingRefreshToken, .network, .upload: return L10n.Basic.error
+        case .missingRefreshToken, .network: return L10n.Basic.error
         }
     }
 
     var message: String {
         switch self {
-        case .missingRefreshToken, .upload: return L10n.Basic.Error.message
+        case .missingRefreshToken: return L10n.Basic.Error.message
         case .network(let e):
             switch (e.error as NSError).code {
             case -1001, -1009: return e.error.localizedDescription // timeout and no connection errors
@@ -50,7 +49,7 @@ extension RequestError: ErrorPresentable {
 
     var detailedDescription: String? {
         switch self {
-        case .missingRefreshToken, .upload: return "\(self)"
+        case .missingRefreshToken: return "\(self)"
         case .network(let e):
             guard let request = e.request else {
                 return "\(self)"


### PR DESCRIPTION
Original purpose of this PR was to change type of associated value of `RequestError.upload`. Later on I realised that having separate case was thanks to historical development of our projects.

Right now it should not be necessary to have an extra case so it is removed.