### PR TITLE
Add ability to override `authorizationHeaders` on `AuthJSONAPI`

### DIFF
--- a/ProjectTemplate/Services/BaseAPI/AuthenticatedJSONAPIService.swift
+++ b/ProjectTemplate/Services/BaseAPI/AuthenticatedJSONAPIService.swift
@@ -24,7 +24,7 @@ final class AuthenticatedJSONAPIService: UnauthorizedHandling, JSONAPIServicing 
         let jsonAPI = dependencies.jsonAPI
 
         return authorizationHeadersProducer()
-            .flatMap(.latest) { jsonAPI.request(address, method: method, parameters: parameters, encoding: encoding, headers: headers + $0) }
+            .flatMap(.latest) { jsonAPI.request(address, method: method, parameters: parameters, encoding: encoding, headers: $0 + headers) }
             .flatMapError { [unowned self] in
                 self.unauthorizedHandler(error: $0, authHandler: self.dependencies.authHandler, authorizationHeaders: self.authorizationHeaders) { [unowned self] in
                     self.request(address, method: method, parameters: parameters, encoding: encoding, headers: headers)
@@ -36,7 +36,7 @@ final class AuthenticatedJSONAPIService: UnauthorizedHandling, JSONAPIServicing 
         let jsonAPI = dependencies.jsonAPI
 
         return authorizationHeadersProducer()
-            .flatMap(.latest) { jsonAPI.upload(address, method: method, parameters: parameters, headers: headers + $0) }
+            .flatMap(.latest) { jsonAPI.upload(address, method: method, parameters: parameters, headers: $0 + headers) }
             .flatMapError { [unowned self] in
                 self.unauthorizedHandler(error: $0, authHandler: self.dependencies.authHandler, authorizationHeaders: self.authorizationHeaders) { [unowned self] in
                     self.upload(address, method: method, parameters: parameters, headers: headers)


### PR DESCRIPTION
## Problem

Right now in case when I want to override _Authorization_ header on `AuthenticatedJSONAPIService` it is impossible because it is overwritten by _Authorization_ header provided by `CredentialsProvider` (if any).

It is caused by merging given headers to the `request/upload` function and `authorizationHeaders`. Right now the `authorizationHeaders` always take precedence that's not that convenient.

## Solution

Change order of merged dictionaries so they can't be overwritten by `authorizationHeaders`.