### PR TITLE
Force Tuist to set LaunchScreen during generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - <description> (#<PR_number>, kudos to @<author>)
 ```
 
+- Fix missing LaunchScreen storyboard after generation ([#59](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/59), kudos to @LukasHromadnik)
 - Added LicensePlist ([#58](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/58), kudos to @LukasHromadnik)
 - Removed `todo` from whitelist rules, update tuist ([#57](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/57), kudos to @fortmarek)
 - Add tests to swiftlint's included paths ([#53](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/53), kudos to @fortmarek)

--- a/Tuist/ProjectDescriptionHelpers/CustomInfoPlist.swift
+++ b/Tuist/ProjectDescriptionHelpers/CustomInfoPlist.swift
@@ -12,6 +12,7 @@ public enum CustomInfoPlist {
     internal var value: [String: InfoPlist.Value] {
         let defaultInfoPlist: [String: InfoPlist.Value] = [
             "UIMainStoryboardFile": "",
+            "UILaunchStoryboardName": "LaunchScreen",
             "CFBundleShortVersionString": "$(ACK_PROJECT_VERSION)",
             "CFBundleDisplayName": "$(ACK_APPNAME)",
             "CFBundleVersion": "ACK_BUILD_NUMBER",


### PR DESCRIPTION
Currently when we generate project using `tuist generate` the Launch screen storyboard is not set properly. As a result the app doesn't run on full screen. This PR addresses this issue.

#### Checklist
<!-- DO NOT REMOVE THIS CHECKLIST OR YOU'LL BURN IN HELL 🔥🧨💣 -->
- [x] Updated CHANGELOG.md.
