### PR TITLE
Improve `reactive.errors()` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - <description> (#<PR_number>, kudos to @<author>)
 ```
 
+- Improve usage of `reactive.errors()` to be usable directly with `ErrorPresentable` ([#71](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/71) kudos to @olejnjak)
 - Update to use Xcode 12.4 ([#70](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/70) kudos to @olejnjak)
 - Add `superfluous_disable_command` to white list ([#69](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/69) kudos to @fortmarek)
 - Remove .tuist-bin folder, move Config.swift to Tuist folder, add .disableSynthesizedResourceAccessors generation option ([#68](https://github.com/AckeeCZ/iOS-MVVM-ProjectTemplate/pull/68) kudos to @svastven)

--- a/ProjectTemplate/Extensions/UIResponder+Errors.swift
+++ b/ProjectTemplate/Extensions/UIResponder+Errors.swift
@@ -35,6 +35,16 @@ extension Reactive where Base: UIResponder {
             base.displayError(value)
         }
     }
+
+    /** Binding target for presentable errors on all UIResponders. Typical usage is with UIViewController.
+     
+     reactive.errors() <~ viewModel.actions.fetchOrders.errors
+     */
+    public func errors() -> BindingTarget<ErrorPresentable> {
+        makeBindingTarget { (base, value) in
+            base.displayError(value)
+        }
+    }
 }
 
 public extension UIResponder {


### PR DESCRIPTION
Currently if you have a `Signal<ErrorPresentable, Never>` you have no way to use `reactive.errors()` as its generics requires concrete `ErrorPresentable` implementation which is not satisfied. By adding another overload that uses directly `ErrorPresentable` it can be used even with above mentioned signal.

The original overload cannot be deleted as it would not work with custom error implementations so both overloads are needed.

Theoretically we can discuss if the newly added overload might be changed to a variable, but I think keeping it consistent would be better as you don't have to think whether to use `reactive.errors() <~ ...` or `reactive.errors <~ ...`.

#### Checklist
<!-- DO NOT REMOVE THIS CHECKLIST OR YOU'LL BURN IN HELL 🔥🧨💣 -->
- [x] Updated CHANGELOG.md.
